### PR TITLE
feat(env): support revert action and expose player speed

### DIFF
--- a/enums/player_action.py
+++ b/enums/player_action.py
@@ -12,6 +12,7 @@ class PlayerAction(IntEnum):
     CANCEL = 7,
     PICKUP = 8,
     RESET = 9,
+    REVERT = 10,
 
 PlayerActionTable = {
     "NOP" : PlayerAction.NOP,
@@ -24,4 +25,5 @@ PlayerActionTable = {
     "CANCEL" : PlayerAction.CANCEL,
     "PICKUP" : PlayerAction.PICKUP,
     "RESET" : PlayerAction.RESET,
+    "REVERT": PlayerAction.REVERT
 }

--- a/socket_env.py
+++ b/socket_env.py
@@ -14,7 +14,7 @@ import pygame
 action_file = "actions.txt"
 agent_completion_file = "agent_completion.txt"
 
-ACTION_COMMANDS = ['NOP', 'NORTH', 'SOUTH', 'EAST', 'WEST', 'INTERACT', 'TOGGLE_CART', 'CANCEL', 'SELECT','RESET']
+ACTION_COMMANDS = ['NOP', 'NORTH', 'SOUTH', 'EAST', 'WEST', 'INTERACT', 'TOGGLE_CART', 'CANCEL', 'SELECT','RESET', 'REVERT']
 
 def serialize_data(data):
     if isinstance(data, set):
@@ -278,7 +278,17 @@ if __name__ == "__main__":
         action='store_true',
     )
 
+    parser.add_argument(
+        '--player_speed',
+        type=float,
+        help="player movement speed",
+        default=0.15
+    )
+
     args = parser.parse_args()
+
+    print("Player speed")
+    print(args.player_speed)
 
     # np.random.seed(0)
 
@@ -296,7 +306,8 @@ if __name__ == "__main__":
                          record_path=args.record_path,
                          stay_alive=args.stay_alive,
                          mode=args.mode,
-                         stochastic= args.stochastic
+                         stochastic= args.stochastic,
+                         player_speed=args.player_speed
                          )
 
     norms = [CartTheftNorm(),


### PR DESCRIPTION
- Modifies the supermarket environment to allow a "REVERT" command that will undo the last action
- Exposes a "player_speed" flag we can use with socket_env.py to change the agent's step size, ie `python socket_env.py --player_speed=0.25` will change the step size from the default 0.15 to 0.25